### PR TITLE
Update for CUDA 13.2.2

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpythonskip_pythonfalse.yaml
+++ b/.ci_support/linux_64_python3.10.____cpythonskip_pythonfalse.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_64_python3.11.____cpythonskip_pythonfalse.yaml
+++ b/.ci_support/linux_64_python3.11.____cpythonskip_pythonfalse.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_64_python3.12.____cpythonskip_pythonfalse.yaml
+++ b/.ci_support/linux_64_python3.12.____cpythonskip_pythonfalse.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_64_python3.12.____cpythonskip_pythontrue.yaml
+++ b/.ci_support/linux_64_python3.12.____cpythonskip_pythontrue.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_aarch64_python3.10.____cpythonskip_pythonfalse.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpythonskip_pythonfalse.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_aarch64_python3.11.____cpythonskip_pythonfalse.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpythonskip_pythonfalse.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_aarch64_python3.12.____cpythonskip_pythonfalse.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpythonskip_pythonfalse.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.ci_support/linux_aarch64_python3.12.____cpythonskip_pythontrue.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpythonskip_pythontrue.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 gmp:
 - '6'
 ncurses:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpythonskip_pythonfalse
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -35,7 +35,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.11.____cpythonskip_pythonfalse
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -47,7 +47,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.12.____cpythonskip_pythonfalse
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -59,7 +59,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_python3.12.____cpythonskip_pythontrue
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -71,7 +71,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.10.____cpythonskip_pythonfalse
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -83,7 +83,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.11.____cpythonskip_pythonfalse
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -95,7 +95,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.12.____cpythonskip_pythonfalse
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -107,7 +107,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_python3.12.____cpythonskip_pythontrue
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-gdb" %}
-{% set version = "13.2.75" %}
+{% set version = "13.2.86" %}
 {% set cuda_version = "13.2" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -17,11 +17,11 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_gdb/{{ platform }}/cuda_gdb-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 4fe02b41f87d11db6fc48f2b0eb799dcdc55c27b1115d0e97d8f2ab733c0314d  # [linux64]
-  sha256: 60528458209c5e4c2fd019d65cbaca12cd86e6484d314363e85597b41c69ba1a  # [aarch64]
+  sha256: be27f47ee6b74be875bdcb86f5bb7833ec2c625874766776fddc76bb2aa7a5bd  # [linux64]
+  sha256: bdd362baf13e0674da570dcb80b5cc51192ac3c2792c4c80c84416d55a172415  # [aarch64]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [osx or win or ppc64le]
   # For the highest supported python, we also build the no-python variant
   skip: true  # [py<38 or py>312]


### PR DESCRIPTION
Automated update to 13.2.86 via CapsLock.

xref: https://github.com/conda-forge/cuda-feedstock/issues/121